### PR TITLE
fix Scatterv! function signature in docstring

### DIFF
--- a/src/collective.jl
+++ b/src/collective.jl
@@ -131,7 +131,7 @@ end
 
 
 """
-    Scatterv!(sendbuf, T, root, comm)
+    Scatterv!(sendbuf, recvbuf, root, comm)
 
 Splits the buffer `sendbuf` in the `root` process into `Comm_size(comm)` chunks and sends
 the `j`th chunk to the process of rank `j-1` into the `recvbuf` buffer.


### PR DESCRIPTION
Noticed that the signature is wrong when taking a look at https://juliaparallel.github.io/MPI.jl/latest/collective/#MPI.Scatterv!.